### PR TITLE
fix: footer blocks spacing in mobile screen

### DIFF
--- a/src/components/layout/Footer.js
+++ b/src/components/layout/Footer.js
@@ -90,8 +90,8 @@ const Footer = () => (
           </div>
         </div>
         <div className="w-full lg:w-6/12 px-4">
-          <div className="flex flex-wrap items-top mb-6">
-            <div className="w-full lg:w-4/12 px-4 ml-auto">
+          <div className="flex flex-wrap items-top mb-0 md:mb-6">
+            <div className="w-full lg:w-4/12 px-0 md:px-4 ml-auto mb-4 md:mb-0">
               <span className="block uppercase text-gray-600 text-sm font-semibold mb-2">
                 Useful Links
               </span>
@@ -124,7 +124,7 @@ const Footer = () => (
               </ul>
             </div>
             <br />
-            <div className="w-full lg:w-4/12 px-4">
+            <div className="w-full lg:w-4/12 px-0 md:px-4">
               <span className="block uppercase text-gray-600 text-sm font-semibold mb-2">
                 Other Resources
               </span>


### PR DESCRIPTION
👋🏻 In this PR I fixed some spacing issues in footer blocks [mobile screen]

# Before
![Screenshot from 2021-10-05 14-08-42](https://user-images.githubusercontent.com/60013703/136029700-7d32aa3f-3d97-4158-8110-e2b908b7ae5f.png)

# After
![Screenshot from 2021-10-05 14-09-39](https://user-images.githubusercontent.com/60013703/136029764-b998761d-c36b-4aa5-b4d8-bbdb6f248d82.png)

