### PR TITLE
remove unnecessary button margin

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -13,7 +13,7 @@ const Button = ({ children, className = '', size }) => {
       className={`
         ${sizes[size] || sizes.default}
         ${className}
-        bg-gradient-to-r from-purple-400 to-blue-500 hover:from-pink-500 hover:to-orange-500 text-white font-semibold px-6 py-3 rounded-full mr-6 
+        bg-gradient-to-r from-purple-400 to-blue-500 hover:from-pink-500 hover:to-orange-500 text-white font-semibold px-6 py-3 rounded-full
     `}
     >
       {children}


### PR DESCRIPTION
This PR remove unnecessary margin that ruins button position

# Before [ Buttons not centered!! ]
![Screenshot from 2021-10-05 20-10-33](https://user-images.githubusercontent.com/60013703/136087854-b34818de-37dc-47df-972d-f21cfb284193.png)
![Screenshot from 2021-10-05 20-13-24](https://user-images.githubusercontent.com/60013703/136087986-f7780319-f032-4be6-9a3c-cec8ea178848.png)

# After [ Buttons centered 😎 ]

![Screenshot from 2021-10-05 20-11-25](https://user-images.githubusercontent.com/60013703/136088370-aac823a3-0d8a-4ebd-b61d-19b123495eb3.png)
![Screenshot from 2021-10-05 20-17-14](https://user-images.githubusercontent.com/60013703/136088550-ac0bce8d-69c6-4a15-bc04-59d758eec577.png)


