### PR TITLE
fix: removed unwanted outline

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -13,7 +13,7 @@ const Button = ({ children, className = '', size }) => {
       className={`
         ${sizes[size] || sizes.default}
         ${className}
-        bg-gradient-to-r from-purple-400 to-blue-500 hover:from-pink-500 hover:to-orange-500 text-white font-semibold px-6 py-3 rounded-full
+        bg-gradient-to-r from-purple-400 to-blue-500 hover:from-pink-500 hover:to-orange-500 text-white font-semibold px-6 py-3 rounded-full focus:outline-none
     `}
     >
       {children}


### PR DESCRIPTION
## Issue
When the cursor is focused on any button, then it makes an unnecessary outline around the button that does not look nice.

![Screenshot from 2021-10-10 04-02-28](https://user-images.githubusercontent.com/67067955/136675363-20870af3-32fc-4433-9b67-da1075b66af1.png)

## Solution 
added `outline:none` on button:focus
